### PR TITLE
Bumped dependency version to fix minimum version test.

### DIFF
--- a/structural/Cargo.toml
+++ b/structural/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structural"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -63,7 +63,7 @@ all=[
 
 
 [dependencies]
-structural_derive={version="=0.4.0",path="../structural_derive"}
+structural_derive={version="=0.4.2",path="../structural_derive"}
 
 [dependencies.core_extensions]
 version="0.1.16"

--- a/structural_derive/Cargo.toml
+++ b/structural_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structural_derive"
-version = "0.4.0"
+version = "0.4.2"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -56,5 +56,5 @@ features=["full","extra-traits"]
 ###### as_derive_utils
 
 [dependencies.as_derive_utils]
-version="0.8.2"
+version="0.8.3"
 default-features=false


### PR DESCRIPTION
Bumped as_derive_utils dependency to 0.8.3

Bumped patch version of structural and structural_derive to 0.4.2