### PR TITLE
Fix grammatical error in library description

### DIFF
--- a/structural/src/lib.rs
+++ b/structural/src/lib.rs
@@ -1,6 +1,6 @@
 /*!
 
-This library provides field accessor traits,and emulation of structural types.
+This library provides field accessor traits and emulation of structural types.
 
 # Features
 


### PR DESCRIPTION
A comma between two items in a list (e.g. "War, and Peace") is grammatically incorrect. 